### PR TITLE
Wire in column names, add postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Domain Events Bundle
 
-TODO: Add instructions for doctrine mapping, route domainEvent
-
 ## Installation
 
 ```bash
@@ -197,6 +195,6 @@ vendor/bin/phpspec run
 
 ## TODO
 
--   Add functional tests
--   Improve OutboxTransportFactory with additional options in the DSN
--
+- Add functional tests
+- Improve OutboxTransportFactory with additional options in the DSN
+- Add instructions for doctrine mapping and routing DomainEvent

--- a/README.md
+++ b/README.md
@@ -198,3 +198,4 @@ vendor/bin/phpspec run
 - Add functional tests
 - Improve OutboxTransportFactory with additional options in the DSN
 - Add instructions for doctrine mapping and routing DomainEvent
+- Fix issues around Carbon serialization

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Domain Events Bundle
 
+TODO: Add instructions for doctrine mapping, route domainEvent
+
 ## Installation
 
 ```bash

--- a/src/DependencyInjection/LingodaDomainEventsExtension.php
+++ b/src/DependencyInjection/LingodaDomainEventsExtension.php
@@ -28,7 +28,6 @@ final class LingodaDomainEventsExtension extends Extension
 
         $this->useCustomMessageBusIfSpecified($config, $container);
         $this->configureEventPublishingSubscriber($config, $container);
-        $this->registerDoctrineTypes();
     }
 
     /**
@@ -57,10 +56,5 @@ final class LingodaDomainEventsExtension extends Extension
 
         $definition = $container->getDefinition('lingoda_domain_events.event_subscriber.publisher');
         $definition->replaceArgument(1, $enabled);
-    }
-
-    private function registerDoctrineTypes(): void
-    {
-        Type::addType('byte_object', ByteObjectType::class);
     }
 }

--- a/src/DependencyInjection/LingodaDomainEventsExtension.php
+++ b/src/DependencyInjection/LingodaDomainEventsExtension.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Lingoda\DomainEventsBundle\DependencyInjection;
 
+use Doctrine\DBAL\Types\Type;
+use Lingoda\DomainEventsBundle\Infra\Doctrine\Type\ByteObjectType;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -26,6 +28,7 @@ final class LingodaDomainEventsExtension extends Extension
 
         $this->useCustomMessageBusIfSpecified($config, $container);
         $this->configureEventPublishingSubscriber($config, $container);
+        $this->registerDoctrineTypes();
     }
 
     /**
@@ -54,5 +57,10 @@ final class LingodaDomainEventsExtension extends Extension
 
         $definition = $container->getDefinition('lingoda_domain_events.event_subscriber.publisher');
         $definition->replaceArgument(1, $enabled);
+    }
+
+    private function registerDoctrineTypes(): void
+    {
+        Type::addType('byte_object', ByteObjectType::class);
     }
 }

--- a/src/DependencyInjection/LingodaDomainEventsExtension.php
+++ b/src/DependencyInjection/LingodaDomainEventsExtension.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace Lingoda\DomainEventsBundle\DependencyInjection;
 
-use Doctrine\DBAL\Types\Type;
-use Lingoda\DomainEventsBundle\Infra\Doctrine\Type\ByteObjectType;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;

--- a/src/Infra/Doctrine/Entity/OutboxRecord.php
+++ b/src/Infra/Doctrine/Entity/OutboxRecord.php
@@ -7,10 +7,11 @@ namespace Lingoda\DomainEventsBundle\Infra\Doctrine\Entity;
 use Carbon\CarbonImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Lingoda\DomainEventsBundle\Domain\Model\DomainEvent;
+use Lingoda\DomainEventsBundle\Infra\Doctrine\Repository\OutboxRecordRepository;
 use Webmozart\Assert\Assert;
 
 /**
- * @ORM\Entity(repositoryClass="Lingoda\DomainEventsBundle\Infra\Doctrine\Repository\OutboxRecordRepository")
+ * @ORM\Entity(repositoryClass=OutboxRecordRepository::class)
  * @ORM\Table(name=self::TABLE_NAME, indexes={
  *     @ORM\Index(name="entity_type_published_idx", columns={"entityId", "eventType", "publishedOn"}),
  *     @ORM\Index(name="occurred_published_idx", columns={"occurredAt", "publishedOn"}),
@@ -28,27 +29,27 @@ class OutboxRecord
     private string $id;
 
     /**
-     * @ORM\Column(type="string", nullable=false)
+     * @ORM\Column(name="eventType", type="string", nullable=false)
      */
     private string $eventType;
 
     /**
-     * @ORM\Column(type="object", nullable=false)
+     * @ORM\Column(name="domainEvent", type="object", nullable=false)
      */
     private object $domainEvent;
 
     /**
-     * @ORM\Column(type="string", length=36, nullable=false)
+     * @ORM\Column(name="entityId", type="string", length=36, nullable=false)
      */
     private string $entityId;
 
     /**
-     * @ORM\Column(type="carbon_immutable", nullable=false)
+     * @ORM\Column(name="occurredAt", type="carbon_immutable", nullable=false)
      */
     private CarbonImmutable $occurredAt;
 
     /**
-     * @ORM\Column(type="carbon_immutable", nullable=true)
+     * @ORM\Column(name="publishedOn", type="carbon_immutable", nullable=true)
      */
     private ?CarbonImmutable $publishedOn;
 

--- a/src/Infra/Doctrine/Entity/OutboxRecord.php
+++ b/src/Infra/Doctrine/Entity/OutboxRecord.php
@@ -34,7 +34,7 @@ class OutboxRecord
     private string $eventType;
 
     /**
-     * @ORM\Column(name="domainEvent", type="object", nullable=false)
+     * @ORM\Column(name="domainEvent", type="byte_object", nullable=false)
      */
     private object $domainEvent;
 

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -23,7 +23,7 @@ class ByteObjectType extends ObjectType
     {
         $value = parent::convertToDatabaseValue($value, $platform);
 
-        if ($platform::class === PostgreSQLPlatform::class) {
+        if (is_a($platform, PostgreSQLPlatform::class)) {
             $value = pg_escape_bytea($value);
         }
 

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -4,8 +4,12 @@ namespace Lingoda\DomainEventsBundle\Infra\Doctrine\Type;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\ObjectType;
 
+/**
+ * Workaround for https://github.com/doctrine/orm/issues/4029
+ */
 class ByteObjectType extends ObjectType
 {
     public const TYPE = 'byte_object';
@@ -13,6 +17,17 @@ class ByteObjectType extends ObjectType
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getBlobTypeDeclarationSQL($column);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        $value = parent::convertToDatabaseValue($value, $platform);
+
+        if ($platform::class === PostgreSQLPlatform::class) {
+            $value = pg_escape_bytea($value);
+        }
+
+        return $value;
     }
 
     public function getBindingType(): int

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -30,8 +30,14 @@ class ByteObjectType extends ObjectType
         return $value;
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform): object
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?object
     {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = is_resource($value) ? stream_get_contents($value) : $value;
+
         if (is_a($platform, PostgreSQLPlatform::class)) {
             $value = str_replace('\0', chr(0), $value);
         }

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -24,10 +24,19 @@ class ByteObjectType extends ObjectType
         $value = parent::convertToDatabaseValue($value, $platform);
 
         if (is_a($platform, PostgreSQLPlatform::class)) {
-            $value = pg_escape_bytea($value);
+            $value = str_replace(chr(0), '\0', $value);
         }
 
         return $value;
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (is_a($platform, PostgreSQLPlatform::class)) {
+            $value = str_replace('\0', chr(0), $value);
+        }
+
+        return parent::convertToPHPValue($value, $platform);
     }
 
     public function getBindingType(): int

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Types\ObjectType;
 
 class ByteObjectType extends ObjectType
 {
+    public const TYPE = 'byte_object';
+
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getBlobTypeDeclarationSQL($column);
@@ -20,6 +22,6 @@ class ByteObjectType extends ObjectType
 
     public function getName(): string
     {
-        return 'byte_object';
+        return self::TYPE;
     }
 }

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lingoda\DomainEventsBundle\Infra\Doctrine\Type;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ObjectType;
+
+class ByteObjectType extends ObjectType
+{
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getBlobTypeDeclarationSQL($column);
+    }
+
+    public function getBindingType(): int
+    {
+        return ParameterType::LARGE_OBJECT;
+    }
+
+    public function getName(): string
+    {
+        return 'byte_object';
+    }
+}

--- a/src/Infra/Doctrine/Type/ByteObjectType.php
+++ b/src/Infra/Doctrine/Type/ByteObjectType.php
@@ -19,7 +19,7 @@ class ByteObjectType extends ObjectType
         return $platform->getBlobTypeDeclarationSQL($column);
     }
 
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         $value = parent::convertToDatabaseValue($value, $platform);
 
@@ -30,7 +30,7 @@ class ByteObjectType extends ObjectType
         return $value;
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): object
     {
         if (is_a($platform, PostgreSQLPlatform::class)) {
             $value = str_replace('\0', chr(0), $value);

--- a/src/LingodaDomainEventsBundle.php
+++ b/src/LingodaDomainEventsBundle.php
@@ -4,8 +4,16 @@ declare(strict_types = 1);
 
 namespace Lingoda\DomainEventsBundle;
 
+use Doctrine\DBAL\Types\Type;
+use Lingoda\DomainEventsBundle\Infra\Doctrine\Type\ByteObjectType;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class LingodaDomainEventsBundle extends Bundle
 {
+    public function __construct()
+    {
+        if (!Type::hasType(ByteObjectType::TYPE)) {
+            Type::addType(ByteObjectType::TYPE, ByteObjectType::class);
+        }
+    }
 }


### PR DESCRIPTION
- Do not rely on global column name generation rule as it breaks indices
- Escape null characters for postgres