### PR TITLE
Reverted public to protected on recordEvent

### DIFF
--- a/src/Domain/Model/Traits/EventRecorderTrait.php
+++ b/src/Domain/Model/Traits/EventRecorderTrait.php
@@ -26,7 +26,7 @@ trait EventRecorderTrait
         $this->recordedEvents = [];
     }
 
-    public function recordEvent(DomainEvent $domainEvent): void
+    protected function recordEvent(DomainEvent $domainEvent): void
     {
         $this->recordedEvents[] = $domainEvent;
     }


### PR DESCRIPTION
Public `recordEvent` would be bad design. The domain only can and should raise events through internal state changes.