### PR TITLE
Allow Symfony 7.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/orm": "^2.10",
         "doctrine/dbal": "3.4",
-        "nesbot/carbon": "^2.48",
-        "symfony/event-dispatcher": "^4.4 || ^5.3 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.2 || ^6.0",
-        "symfony/lock": "^5.3 || ^6.0",
-        "symfony/messenger": "^5.3 || ^6.0",
+        "nesbot/carbon": "^2.48 || ^3.0",
+        "symfony/event-dispatcher": "^5.3 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.3 || ^6.0 || ^7.0",
+        "symfony/lock": "^5.3 || ^6.0 || ^7.0",
+        "symfony/messenger": "^5.3 || ^6.0 || ^7.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
@@ -24,7 +24,7 @@
         "phpstan/phpstan-symfony": "^1.2",
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^9.5",
-        "symfony/phpunit-bridge": "^6.1"
+        "symfony/phpunit-bridge": "^6.1 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Dropped support for Symfony 4.x
- Allowed Symfony 7.x