### PR TITLE
Converted doctrine subscriber to listener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "doctrine/dbal": "^3.3",
-        "doctrine/doctrine-bundle": "^2.7",
+        "doctrine/dbal": "^3.4",
+        "doctrine/doctrine-bundle": "^2.8",
         "doctrine/orm": "^2.15",
         "nesbot/carbon": "^2.71 || ^3.0",
         "symfony/event-dispatcher": "^6.4|^7.0",

--- a/spec/Infra/Doctrine/EventSubscriber/PersistDomainEventsSubscriberSpec.php
+++ b/spec/Infra/Doctrine/EventSubscriber/PersistDomainEventsSubscriberSpec.php
@@ -6,7 +6,6 @@ namespace spec\Lingoda\DomainEventsBundle\Infra\Doctrine\EventSubscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PreFlushEventArgs;
-use Doctrine\ORM\Events;
 use Doctrine\ORM\UnitOfWork;
 use Lingoda\DomainEventsBundle\Domain\Model\ContainsEvents;
 use Lingoda\DomainEventsBundle\Domain\Model\DomainEvent;
@@ -25,13 +24,6 @@ class PersistDomainEventsSubscriberSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType(PersistDomainEventsSubscriber::class);
-    }
-
-    function it_listens_to_events()
-    {
-        $this->getSubscribedEvents()->shouldBeEqualTo([
-            Events::preFlush,
-        ]);
     }
 
     function it_can_persist_domain_events(
@@ -64,7 +56,7 @@ class PersistDomainEventsSubscriberSpec extends ObjectBehavior
         ]);
 
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
-        $preFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $preFlushEventArgs->getObjectManager()->willReturn($entityManager);
 
         $insertedEntity->clearRecordedEvents()->shouldBeCalledOnce();
         $insertedEntity->getRecordedEvents()->willReturn([$domainEvent, $replaceableDomainEvent]);
@@ -102,7 +94,7 @@ class PersistDomainEventsSubscriberSpec extends ObjectBehavior
         $unitOfWork->getScheduledEntityInsertions()->willReturn([]);
 
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
-        $preFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $preFlushEventArgs->getObjectManager()->willReturn($entityManager);
 
         $updatedEntity->clearRecordedEvents()->shouldBeCalledOnce();
         $updatedEntity->getRecordedEvents()->willReturn([$domainEvent]);
@@ -131,7 +123,7 @@ class PersistDomainEventsSubscriberSpec extends ObjectBehavior
         ]);
 
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
-        $preFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $preFlushEventArgs->getObjectManager()->willReturn($entityManager);
 
         $scheduledInsertEntity->clearRecordedEvents()->shouldBeCalledOnce();
         $scheduledInsertEntity->getRecordedEvents()->willReturn([$domainEvent]);

--- a/src/Infra/Doctrine/EventSubscriber/PersistDomainEventsSubscriber.php
+++ b/src/Infra/Doctrine/EventSubscriber/PersistDomainEventsSubscriber.php
@@ -4,9 +4,7 @@ declare(strict_types = 1);
 
 namespace Lingoda\DomainEventsBundle\Infra\Doctrine\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\PreFlushEventArgs;
-use Doctrine\ORM\Events;
 use Lingoda\DomainEventsBundle\Domain\Model\ContainsEvents;
 use Lingoda\DomainEventsBundle\Domain\Model\OutboxStore;
 use Lingoda\DomainEventsBundle\Domain\Model\ReplaceableDomainEvent;
@@ -14,7 +12,7 @@ use Lingoda\DomainEventsBundle\Domain\Model\ReplaceableDomainEvent;
 /**
  * Doctrine entity listener stores recorded events in the outbox store
  */
-final class PersistDomainEventsSubscriber implements EventSubscriber
+final class PersistDomainEventsSubscriber
 {
     private OutboxStore $outboxStore;
 
@@ -23,14 +21,9 @@ final class PersistDomainEventsSubscriber implements EventSubscriber
         $this->outboxStore = $outboxStore;
     }
 
-    public function getSubscribedEvents(): array
-    {
-        return [Events::preFlush];
-    }
-
     public function preFlush(PreFlushEventArgs $eventArgs): void
     {
-        $uow = $eventArgs->getEntityManager()->getUnitOfWork();
+        $uow = $eventArgs->getObjectManager()->getUnitOfWork();
 
         foreach ($uow->getIdentityMap() as $entities) {
             $this->persistRecordedEventsFromEntities($entities);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -26,7 +26,7 @@
                  class="Lingoda\DomainEventsBundle\Infra\Doctrine\EventSubscriber\PersistDomainEventsSubscriber"
                  public="false">
             <argument type="service" id="lingoda_domain_events.repository.outbox_store_doctrine"/>
-            <tag name="doctrine.event_subscriber" connection="default" priority="-1000"/>
+            <tag name="doctrine.event_listener" event="preFlush" connection="default" priority="-1000"/>
         </service>
 
         <service id="lingoda_domain_events.repository.outbox_store_doctrine"


### PR DESCRIPTION
Converted doctrine subscriber to listener, as subscriber interface is deprecated and is replaced by attribute on doctrine bundle v2.8+