### PR TITLE
feat: allow Symfony 8, bump PHP ^8.3, PHPStan 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '8.2', '8.3' ]
-                symfony: [ '6.4', '7.1' ]
+                php: [ '8.3', '8.4' ]
+                symfony: [ '6.4', '7.3', '8.0' ]
                 install-args: ['', '--prefer-lowest --prefer-stable']
             fail-fast: false
         steps:

--- a/composer.json
+++ b/composer.json
@@ -4,28 +4,28 @@
     "type": "symfony-bundle",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "doctrine/dbal": "^3.4",
         "doctrine/doctrine-bundle": "^2.8",
         "doctrine/orm": "^2.15",
         "nesbot/carbon": "^2.71 || ^3.0",
-        "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/lock": "^6.4|^7.0",
-        "symfony/messenger": "^6.4|^7.0",
+        "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+        "symfony/lock": "^6.4|^7.0|^8.0",
+        "symfony/messenger": "^6.4|^7.0|^8.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
         "nyholm/symfony-bundle-test": "^3.0",
-        "phpspec/phpspec": "^7.5",
+        "phpspec/phpspec": "^7.5 || ^8.0",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^1.12",
-        "phpstan/phpstan-doctrine": "^1.5",
-        "phpstan/phpstan-symfony": "^1.4",
-        "phpstan/phpstan-webmozart-assert": "^1.2",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-doctrine": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^9.6",
-        "rector/rector": "^1.2",
-        "symfony/phpunit-bridge": "^6.4|^7.0"
+        "rector/rector": "^2.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -52,7 +52,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "^6.4|^7.0"
+            "require": "^6.4|^7.0|^8.0"
         }
     }
 }

--- a/phpstan.common.neon
+++ b/phpstan.common.neon
@@ -1,15 +1,7 @@
-includes:
-	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
 parameters:
     tmpDir: .phpstan-cache
     level: 8
     checkMissingCallableSignature: true
-    polluteScopeWithLoopInitialAssignments: false
-    polluteScopeWithAlwaysIterableForeach: false
-    checkAlwaysTrueCheckTypeFunctionCall: true
-    checkAlwaysTrueInstanceof: true
-    checkAlwaysTrueStrictComparison: true
-    checkExplicitMixedMissingReturn: true
     checkFunctionNameCase: true
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,5 @@ parameters:
             message: "#^Property Lingoda\\\\DomainEventsBundle\\\\Infra\\\\Doctrine\\\\Entity\\\\OutboxRecord\\:\\:\\$id is never written, only read\\.$#"
             count: 1
             path: src/Infra/Doctrine/Entity/OutboxRecord.php
+        # Symfony Config TreeBuilder returns NodeDefinition, but children() is on ArrayNodeDefinition
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::\w+\(\)\.#'


### PR DESCRIPTION
- PHP `^8.2` -> `^8.3`
- Symfony constraints: add `|^8.0`
- PHPStan `^1.12` -> `^2.0`, Rector `^1.2` -> `^2.0`, phpspec `^7.5` -> `^7.5 || ^8.0`
- CI matrix: PHP 8.3/8.4 x Symfony 6.4/7.3/8.0

34 phpspec examples + 1 PHPUnit test pass. PHPStan clean.

Release as **2.1.0**.