### PR TITLE
Fix outbox index column order for unpublished event queries

### DIFF
--- a/src/Infra/Doctrine/Entity/OutboxRecord.php
+++ b/src/Infra/Doctrine/Entity/OutboxRecord.php
@@ -13,7 +13,7 @@ use Webmozart\Assert\Assert;
 #[ORM\Entity(repositoryClass: OutboxRecordRepository::class)]
 #[ORM\Table(name: self::TABLE_NAME)]
 #[ORM\Index(name: 'entity_type_published_idx', columns: ['entityId', 'eventType', 'publishedOn'])]
-#[ORM\Index(name: 'occurred_published_idx', columns: ['occurredAt', 'publishedOn'])]
+#[ORM\Index(name: 'idx_unpublished_occurred', columns: ['publishedOn', 'occurredAt'])]
 class OutboxRecord
 {
     public const TABLE_NAME = 'outbox';


### PR DESCRIPTION
## Summary

Reorder outbox composite index columns from `(occurredAt, publishedOn)` to `(publishedOn, occurredAt)`.

The primary query pattern filters `WHERE publishedOn IS NULL ORDER BY occurredAt ASC LIMIT 1`. Placing the equality/null filter column first allows an index seek instead of a full range scan.